### PR TITLE
Revert "[TNL-8176] - Improve description for InvalidHTML exception for readability."

### DIFF
--- a/olxcleaner/loader/xml_exceptions.py
+++ b/olxcleaner/loader/xml_exceptions.py
@@ -28,7 +28,7 @@ class InvalidHTML(CourseError):
 
     def __init__(self, filename, **kwargs):
         super().__init__(filename)
-        self._description = f"InvalidHTML ({filename}): {kwargs['error']}"
+        self._description = kwargs['error']
 
 class CourseXMLName(CourseError):
     """The master file was not called `course.xml`."""

--- a/tests/test_load_xml.py
+++ b/tests/test_load_xml.py
@@ -80,7 +80,7 @@ def handle_course2_errors(errorstore):
     assert_error(errorstore, InvalidPointer, 'sequential/mysequential.xml', "The <vertical url_name='myvertical9' display_name='Hi there'> tag looks like it is an invalid pointer tag")
     assert_error(errorstore, UnexpectedContent, 'vertical/myvertical10.xml', "The <vertical url_name='myvertical10' display_name='something'> tag should not contain any text (Here is some co...)")
     assert_error(errorstore, UnexpectedContent, 'sequential/mysequential.xml', "The <vertical> tag should not contain any text (Here's some bad...)")
-    assert_error(errorstore, InvalidHTML, 'html/html3.html', 'InvalidHTML (html/html3.html): Unexpected end tag : b, line 1, column 34')
+    assert_error(errorstore, InvalidHTML, 'html/html3.html', 'Unexpected end tag : b, line 1, column 34')
     assert_error(errorstore, PossiblePointer, 'vertical/myvertical1.xml', "The <problem url_name='problem2'> tag is not a pointer, but a file that it could point to exists (problem/problem2.xml)")
     assert_error(errorstore, PossibleHTMLPointer, 'html/html6.xml', "The <html url_name='html6'> tag is not a pointer, but a file that it could point to exists (html/html3.html)")
     assert_error(errorstore, PossibleHTMLPointer, 'vertical/myvertical3.xml', "The <html> tag is not a pointer, but a file that it could point to exists (html/html3.html)")


### PR DESCRIPTION
### Reverts openedx/olxcleaner#6

### REASON FOR REVERT

Initially, we were manually looking at the errors within an `errorstore` by looping through the `errorstore.errors`. We found at that time the description of `invalidHTML` exception was not conclusive enough (missing file_name)
We have now realized the `report_error()` method handles this headache and presents a conclusive error message (this method is also the one used in `edx-platform`). Hence, we are removing this repetitive step.