### PR TITLE
[TNL-8221] - Fix issue with SelfPointer Error and Improve InvalidPointer message

### DIFF
--- a/olxcleaner/loader/xml_exceptions.py
+++ b/olxcleaner/loader/xml_exceptions.py
@@ -64,12 +64,12 @@ class URLNameMismatch(CourseError):
         self._description = f"The opening <{kwargs['tag']}> tag has a mismatched url in url_name."
 
 class InvalidPointer(CourseError):
-    """This tag appears to be trying to point to another file, but contains unexpected attributes, and is hence not pointing."""
+    """This tag looks like it's trying to be a pointer but contains other attributes."""
     _level = ErrorLevel.ERROR
 
     def __init__(self, filename, **kwargs):
         super().__init__(filename)
-        self._description = f"The {kwargs['edxobj']} tag looks like it is an invalid pointer tag"
+        self._description = f"The {kwargs['edxobj']} tag looks like it's trying to be a pointer but contains other attributes."
 
 class FileDoesNotExist(CourseError):
     """The file being pointed to does not exist."""
@@ -86,6 +86,14 @@ class SelfPointer(CourseError):
     def __init__(self, filename, **kwargs):
         super().__init__(filename)
         self._description = f"The tag {kwargs['edxobj']} tag appears to be pointing to itself"
+
+class PointerAlreadyPointedAt(CourseError):
+    """A tag that has been pointed to and is pointing to another url_name"""
+    _level = ErrorLevel.ERROR
+
+    def __init__(self, filename, **kwargs):
+        super().__init__(filename)
+        self._description = f"The {kwargs['edxobj']} tag has been pointed to and is pointing to another url_name"
 
 class UnexpectedTag(CourseError):
     """A tag was found in an inappropriate location (e.g., a `vertical` in a `chapter`), or the tag was not recognized."""

--- a/testcourses/testcourse2/chapter/mychapter.xml
+++ b/testcourses/testcourse2/chapter/mychapter.xml
@@ -1,3 +1,5 @@
 <chapter display_name="chapter name">
   <sequential url_name="mysequential"/>
+  <sequential url_name="sequence2"/>
+  <sequential url_name="some-other-sequential-not-found" />
 </chapter>

--- a/testcourses/testcourse2/sequential/sequence2.xml
+++ b/testcourses/testcourse2/sequential/sequence2.xml
@@ -1,0 +1,2 @@
+<sequential url_name="some-non-existant-sequential">
+</sequential>

--- a/tests/test_load_xml.py
+++ b/tests/test_load_xml.py
@@ -25,8 +25,8 @@ from olxcleaner.loader.xml_exceptions import (
     EmptyTag,
     PossiblePointer,
     PossibleHTMLPointer,
-    DuplicateHTMLName
-)
+    DuplicateHTMLName,
+    PointerAlreadyPointedAt)
 
 def test_no_course():
     errorstore = ErrorStore()
@@ -77,7 +77,6 @@ def handle_course2_errors(errorstore):
     assert_error(errorstore, UnexpectedTag, 'sequential/mysequential.xml', "A <chapter> tag was unexpectedly found inside the <vertical> tag")
     assert_error(errorstore, TagMismatch, 'vertical/myvertical7.xml', 'The file is of type <vertical> but opens with a <chapter> tag')
     assert_error(errorstore, SelfPointer, 'vertical/myvertical8.xml', "The tag <vertical url_name='myvertical8'> tag appears to be pointing to itself")
-    assert_error(errorstore, InvalidPointer, 'sequential/mysequential.xml', "The <vertical url_name='myvertical9' display_name='Hi there'> tag looks like it is an invalid pointer tag")
     assert_error(errorstore, UnexpectedContent, 'vertical/myvertical10.xml', "The <vertical url_name='myvertical10' display_name='something'> tag should not contain any text (Here is some co...)")
     assert_error(errorstore, UnexpectedContent, 'sequential/mysequential.xml', "The <vertical> tag should not contain any text (Here's some bad...)")
     assert_error(errorstore, InvalidHTML, 'html/html3.html', 'Unexpected end tag : b, line 1, column 34')
@@ -93,6 +92,9 @@ def handle_course2_errors(errorstore):
     assert_error(errorstore, EmptyTag,'problem/problem3.xml' , "The <problem url_name='problem3' display_name='Blank Common Problem'> tag is unexpectedly empty")
     assert_error(errorstore, URLNameMismatch, 'video/video3.xml', "The opening <video> tag has a mismatched url in url_name.")
     assert_error(errorstore, URLNameMismatch, 'discussion/discussion1.xml', "The opening <discussion> tag has a mismatched url in url_name.")
+    assert_error(errorstore, InvalidPointer, 'sequential/mysequential.xml', "The <vertical url_name='myvertical9' display_name='Hi there'> tag looks like it's trying to be a pointer but contains other attributes.")
+    assert_error(errorstore, PointerAlreadyPointedAt, 'sequential/sequence2.xml', "The <sequential url_name='some-non-existant-sequential'> tag has been pointed to and is pointing to another url_name")
+    assert_error(errorstore, FileDoesNotExist, 'chapter/mychapter.xml', "The <sequential url_name='some-other-sequential-not-found'> tag points to the file sequential/some-other-sequential-not-found.xml that does not exist")
 
 def test_course3():
     """Test for XML error in course.xml"""


### PR DESCRIPTION
### [TNL-8221](https://openedx.atlassian.net/browse/TNL-8221)
#### Description
Currently, the InvalidPointer error is not very descriptive and easy to understand. In order to improve and make it easier for the course teams to understand this error needs to be improved.

#### Issue
Fix the bug of “SelfPointer” error when it shouldn’t raise this error. Take the following example scenario:

```
chapter1.xml
<chapter display_name="Week 1">
  <sequential url_name="seq1"/>
</chapter>

seq1.xml
<sequential url_name="some-non-existant-sequential">
</sequential>
```
This throws a “SelfPointer” error when it shouldn't
 
