### PR TITLE
Update .travis to work with repo-health

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,26 +1,13 @@
 # Travis continuous integration configuration file
-matrix:
-  include:
-  - language: python
-    python:
-      - "3.6"
-    dist: xenial
-    install:
-      - pip install -r requirements.txt
-      - pip install codecov
-    script:
-      - pytest --cov=olxcleaner --cov-report=term-missing
-    after_success:
-      - codecov
-
-  - language: python
-    python:
-      - "3.7"
-    dist: xenial
-    install:
-      - pip install -r requirements.txt
-      - pip install codecov
-    script:
-      - pytest --cov=olxcleaner --cov-report=term-missing
-    after_success:
-      - codecov
+language: python
+python:
+  - 3.6
+  - 3.7
+dist: xenial
+install:
+  - pip install -r requirements.txt
+  - pip install codecov
+script:
+  - pytest --cov=olxcleaner --cov-report=term-missing
+after_success:
+  - codecov


### PR DESCRIPTION
.travis.yml was testing with python 3.6 and 3.7 by copy-pasting the same config twice. This is not necessary and causes breaks with edx-repo-health checks.