### PR TITLE
docs: various fixes to README and project metadata (0.2.1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,9 @@ Based on this, two scripts are provided that leverage the library:
 * `edx-cleaner` constructs an error report, course tree and course statistics
 * `edx-reporter` constructs a LaTeX file representation of the course structure
 
-Version 0.1.3
-
 Copyright (C) 2018-2019 Jolyon Bloomfield
+
+Copyright (C) 2020-2023 The Center for Reimagining Learning, Inc. and Contributors
 
 ## Links
 

--- a/setup.py
+++ b/setup.py
@@ -11,13 +11,13 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="olxcleaner",
-    version="0.2.0",
+    version="0.2.1",
     author="Jolyon Bloomfield",
     author_email="jolyon@mit.edu",
-    description="Tool to scan edX courses for various errors",
+    description="Tool to scan Open edX courses for various errors",
     long_description=long_description,
     long_description_content_type="text/markdown",
-    url="https://github.com/jolyonb/olxcleaner",
+    url="https://github.com/openedx/olxcleaner",
     license='LICENSE',
     packages=setuptools.find_packages(exclude=['tests']),
     classifiers=[


### PR DESCRIPTION
* No need to add version to README, since it is coded into setup.py
* After 2020, copyright is held by tCRIL and CLA-signed contributors.
* Update setup.py repo URL to openedx org
* Update description to say Open edX, not edX
* bump version 0.2.0 -> 0.2.1