### PR TITLE
chore: cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Based on this, two scripts are provided that leverage the library:
 
 Copyright (C) 2018-2019 Jolyon Bloomfield
 
-Copyright (C) 2020-2023 The Center for Reimagining Learning, Inc. and Contributors
+Copyright (C) 2020-2024 Axim, Inc. and Contributors
 
 ## Links
 
@@ -28,22 +28,22 @@ Copyright (C) 2020-2023 The Center for Reimagining Learning, Inc. and Contributo
 
 This package may be installed from PYPI using `pip install olxcleaner`. It requires python 3.6 or later.
 
-### Repository Installation (advanced) 
+### Repository Installation (Advanced)
 
 Clone this repository, and set up a virtual environment for python 3.6 or later. Run `pip install -r requirements.txt` to install the libraries, followed by `pytest` to ensure that all tests are passing as expected.
 
 ## edx-cleaner Usage
 
-Used to validate OLX (edX XML) code. This is a very light wrapper around the olxcleaner library, but exposes all of the functionality thereof.
+Used to validate OLX (edX XML) code. This is a very light wrapper around the olxcleaner library but exposes all of the functionality thereof.
 
 Basic usage: run `edx-cleaner` in the directory of the course you want to validate.
 
 Command-line options:
 
 ```text
-edx-cleaner [-h] 
+edx-cleaner [-h]
             [-c COURSE]
-            [-p {1,2,3,4,5,6,7,8}] 
+            [-p {1,2,3,4,5,6,7,8}]
             [-t TREE] [-l {0,1,2,3,4}]
             [-q] [-e] [-s] [-S]
             [-f {0,1,2,3,4}]
@@ -52,34 +52,34 @@ edx-cleaner [-h]
 
 * `-h`: Display help.
 * `-c`: Specify the course file to analyze. If not specified, looks for `course.xml` in the current directory. If given a directory, looks for `course.xml` in that directory.
-* `-p`: Specify the validation level you wish analyze the course at:
+* `-p`: Specify the validation level you wish to analyze the course at:
   * 1: Load the course
   * 2: Load the policy and grading policy
   * 3: Validate url_names
-  * 4: Merge policy data with course, ensuring that all references are valid
+  * 4: Merge policy data with the course, ensuring that all references are valid
   * 5: Validate the grading policy
   * 6: Have every object validate itself
   * 7: Parse the course for global errors
   * 8: Parse the course for detailed global errors (default)
 * `-t TREE`: Specify a file to output the tree structure to.
-* `-l`: Specify the depth level to output the tree structure to. Only used if the `-t` option is set. 0 = Course, 1 = Chapter, 2 = Sequential, 3 = Vertical, 4 = Content. 
+* `-l`: Specify the depth level to output the tree structure to. Only used if the `-t` option is set. 0 = Course, 1 = Chapter, 2 = Sequential, 3 = Vertical, 4 = Content.
 * `-q`: Quiet mode. Does not output anything to the screen.
 * `-e`: Suppress error listing. Implied by `-q`.
 * `-s`: Suppress summary of errors. Implied by `-q`.
 * `-S`: Display course statistics (off by default). Overridden by `-q`.
-* `-f`: Select the error level at which to exit with an error code. 0 = DEBUG, 1 = INFO, 2 = WARNING, 3 = ERROR (default), 4 = NEVER. Exit code is set to `1` if an error at the specified level or higher is present.
+* `-f`: Select the error level at which to exit with an error code. 0 = DEBUG, 1 = INFO, 2 = WARNING, 3 = ERROR (default), 4 = NEVER. The exit code is set to `1` if an error at the specified level or higher is present.
 * `-i`: Specify a space-separated list of error names to ignore. See [Error Listing](errors.md).
 
 ## edx-reporter Usage
 
-The olxcleaner library includes modules that parse a course into python objects. This can be useful if you want to scan a course to generate a report. We exploit this in `edx-reporter` to generate a LaTeX report of course structure.
+The olxcleaner library includes modules that parse a course into Python objects. This can be useful if you want to scan a course to generate a report. We exploit this in `edx-reporter` to generate a LaTeX report of course structure.
 
 Basic usage: run `edx-reporter` in the directory of the course you want to generate a report about.
 
 Command-line options:
 
 ```text
-edx-reporter.py [-h] 
+edx-reporter.py [-h]
                 [-c COURSE]
                 [-u]
                 [> latexfile.tex]
@@ -104,14 +104,14 @@ olxcleaner.validate(filename, steps=8, ignore=None, allowed_xblocks=None)
 
 * `filename`: Pass in either the course directory or the path of `course.xml` for the course you wish to validate.
 * `steps`: Choose how many validation steps you wish to perform:
-    * 1: Load the course
-    * 2: Load the policy and grading policy
-    * 3: Validate `url_name`s
-    * 4: Merge policy data with course, ensuring that all references are valid
-    * 5: Validate the grading policy
-    * 6: Have every object validate itself
-    * 7: Parse the course for global errors
-    * 8: Parse the course for global errors that may be time-consuming to detect
+  * 1: Load the course
+  * 2: Load the policy and grading policy
+  * 3: Validate `url_name`s
+  * 4: Merge policy data with course, ensuring that all references are valid
+  * 5: Validate the grading policy
+  * 6: Have every object validate itself
+  * 7: Parse the course for global errors
+  * 8: Parse the course for global errors that may be time-consuming to detect
 * `ignore`: A list of error names to ignore
 * `allowed_xblocks`: A list of all allowed xblocks that course olx may contain.
 

--- a/errors.md
+++ b/errors.md
@@ -44,7 +44,6 @@ Each error has a name that can be used in the `-i` flag to ignore it.
 
 - `WrongObjectType`: The policy file references an object of one type, but that object is found in the course with another type.
 
-
 ## Warnings
 
 - `BadCourseLink`: An internal /course/ link points to a location that doesn't exist.
@@ -79,15 +78,12 @@ Each error has a name that can be used in the `-i` flag to ignore it.
 
 - `SettingOverride`: The policy file is overriding a setting specified in a file.
 
-
 ## Information
 
 - `DuplicateHTMLName`: Two HTML tags point to the same HTML file (`filename` attribute). While this isn't obviously problematic, probably best not to do it.
 
 - `Obsolete`: The way this object has been set up is obsolete.
 
-
 ## Debug
 
 (Currently no errors in this category)
-

--- a/vision.md
+++ b/vision.md
@@ -10,13 +10,11 @@ It is envisioned that this code can be used in many ways to assist with the crea
 
 * Exported courses from Studio can be scanned using this tool in order to pick up errors that are not currently checked by edX (particularly links and dates).
 
-
 ### XML Validation
 
 * Before loading an XML course into Studio, this code can check the XML structure for any errors.
 
 * This code can be used for error detection by educational technologists to simplify their bug sleuthing.
-
 
 ### Report Generation and Course Parsing
 
@@ -28,15 +26,13 @@ It is envisioned that this code can be used in many ways to assist with the crea
 
 * For github workflows, a hook could be added to run this script upon branch push, producing an error report automatically.
 
-
 ## A Community Tool
 
 This code is intended for use by the edX community. Beyond the current possibilities, there are two aspects that should be of value to the community:
 
 * As errors that aren't detected by this tool are found (likely after some sleuthing), the code can be updated to detect such errors.
 
-* As new capabilities for edX are developed, the schema for the new possibilities can be added to this tool so that others can ensure that their code is syntactically correct.  
-
+* As new capabilities for edX are developed, the schema for the new possibilities can be added to this tool so that others can ensure that their code is syntactically correct.
 
 ## Potential edX Buy-in
 

--- a/wishlist.md
+++ b/wishlist.md
@@ -2,19 +2,19 @@
 
 This is a list of features that it would be nice to have in this program.
 
-## Recognize the following tags:
+## Recognize the following tags
 
 - Conditional tags
 - AB Test tags
 
-## Validate Course Updates:
+## Validate Course Updates
 
 - Check that the update file is found (and that json/html aren't clashing)
 - Validate the json/html in course updates
 
-## Parsing:
+## Parsing
 
 - Check textbook and tab structure in course block validation
 - When checking links, check that textbook/tabs links point to somewhere that exists
 - Check that python scripts in problems run (and are preferably wrapped in CDATA)
-- Check that customresponse graders grade correctly when given expected answer
+- Check that custom response graders grade correctly when given expected answer


### PR DESCRIPTION
This will clean up README and some other `.md` files

- Markdown warnings resolved.
- TCRIL renamed to Axim.
- Trailing white spaces removed.
- Some Typos fixed.